### PR TITLE
Refreshing token without providing an access token

### DIFF
--- a/src/filuta_fastapi_users/__init__.py
+++ b/src/filuta_fastapi_users/__init__.py
@@ -1,6 +1,6 @@
 """Ready-to-use and customizable users management for FastAPI."""
 
-__version__ = "12.1.1+2"
+__version__ = "12.1.1+3"
 
 from filuta_fastapi_users import models, schemas  # noqa: F401
 from filuta_fastapi_users.exceptions import InvalidID, InvalidPasswordException

--- a/src/filuta_fastapi_users/__init__.py
+++ b/src/filuta_fastapi_users/__init__.py
@@ -1,6 +1,6 @@
 """Ready-to-use and customizable users management for FastAPI."""
 
-__version__ = "12.1.1+3"
+__version__ = "12.1.1+4"
 
 from filuta_fastapi_users import models, schemas  # noqa: F401
 from filuta_fastapi_users.exceptions import InvalidID, InvalidPasswordException

--- a/src/filuta_fastapi_users/authentication/strategy/base.py
+++ b/src/filuta_fastapi_users/authentication/strategy/base.py
@@ -38,3 +38,6 @@ class Strategy(Protocol, Generic[models.UP, models.ID, models.AP]):
 
     def generate_token(self) -> str:
         ...  # pragma: no cover
+
+    async def get_latest_token_for_user(self, user: models.UP) -> models.AP:
+        ...  # pragma: no cover

--- a/src/filuta_fastapi_users/authentication/strategy/db/adapter.py
+++ b/src/filuta_fastapi_users/authentication/strategy/db/adapter.py
@@ -33,6 +33,10 @@ class AccessTokenDatabase(Protocol, Generic[models.AP]):
         """Delete all tokens for a given user"""
         ...  # pragma: no cover
 
+    async def get_latest_token_for_user(self, user: models.UP) -> models.AP:
+        """Delete latest token for a user"""
+        ...  # pragma: no cover
+
 
 class RefreshTokenDatabase(Protocol, Generic[models.RTP]):
     """Protocol for retrieving, creating and updating refresh tokens from a database."""

--- a/src/filuta_fastapi_users/authentication/strategy/db/strategy.py
+++ b/src/filuta_fastapi_users/authentication/strategy/db/strategy.py
@@ -79,3 +79,6 @@ class DatabaseStrategy(Strategy[models.UP, models.ID, models.AP], Generic[models
 
     def generate_token(self) -> str:
         return secrets.token_urlsafe()
+
+    async def get_latest_token_for_user(self, user: models.UP) -> models.AP:
+        return await self.access_token_db.get_latest_token_for_user(user)

--- a/src/filuta_fastapi_users/filuta_uds/access_token.py
+++ b/src/filuta_fastapi_users/filuta_uds/access_token.py
@@ -106,3 +106,12 @@ class SQLAlchemyAccessTokenDatabase(Generic[models.AP], AccessTokenDatabase[mode
             await self.session.delete(token)
 
         await self.session.commit()
+
+    async def get_latest_token_for_user(self, user: models.UP) -> models.AP:
+        results = await self.session.execute(
+            select(self.access_token_table)
+            .where(self.access_token_table.user_id == user.id)
+            .order_by(self.access_token_table.created_at.desc())  # type: ignore
+            .limit(1)
+        )
+        return results.scalar_one_or_none()

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -6,7 +6,7 @@ def test_import() -> None:
 
 
 def test_version() -> None:
-    assert __version__ == "12.1.1+2"
+    assert __version__ == "12.1.1+3"
 
 
 def test_global_fixture(dummy_fixture: int) -> None:

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -6,7 +6,7 @@ def test_import() -> None:
 
 
 def test_version() -> None:
-    assert __version__ == "12.1.1+3"
+    assert __version__ == "12.1.1+4"
 
 
 def test_global_fixture(dummy_fixture: int) -> None:


### PR DESCRIPTION
Access token is no longer needed when refreshing a token. It is retrieved from the DB instead (to keep the current implementation in place).