### PR TITLE
FIX usafe pyjwt version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ httpx_oauth==0.13.0
 makefun==1.15.1
 passlib[bcrypt]==1.7.4
 pydantic>=2.0.0,<3.0.0
-pyjwt[crypto]==2.10.1
+pyjwt[crypto]==2.12.1
 python-dotenv==1.0.0
 python-multipart==0.0.22
 sqlalchemy==2.0.20

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setuptools.setup(
         "fastapi >=0.65.2",
         "passlib[bcrypt] ==1.7.4",
         "email-validator >=1.1.0,<2.1",
-        "pyjwt[crypto] ==2.10.1",
+        "pyjwt[crypto] ==2.12.1",
         "python-multipart ==0.0.22",
         "makefun >=1.11.2,<2.0.0",
         "pydantic>=2.0.0,<3.0.0",

--- a/src/filuta_fastapi_users/__init__.py
+++ b/src/filuta_fastapi_users/__init__.py
@@ -1,6 +1,6 @@
 """Ready-to-use and customizable users management for FastAPI."""
 
-__version__ = "12.1.1+10"
+__version__ = "12.1.2"
 
 from filuta_fastapi_users import models, schemas  # noqa: F401
 from filuta_fastapi_users.exceptions import InvalidID, InvalidPasswordException

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -6,7 +6,7 @@ def test_import() -> None:
 
 
 def test_version() -> None:
-    assert __version__ == "12.1.1+10"
+    assert __version__ == "12.1.2"
 
 
 def test_global_fixture(dummy_fixture: int) -> None:


### PR DESCRIPTION
There is CVE with pyjwt version used, https://getsafety.com/vulnerabilities/89028 this

- updates pyjwt to 2.12.1
- bumps package version to 12.1.2